### PR TITLE
Ashley zhu pydantic config

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Use Ubuntu 24.04 for stability
-FROM ubuntu:24.04
+FROM ubuntu:22.04
 
 # Set environment variable for non-interactive installation
 ENV DEBIAN_FRONTEND=noninteractive

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,3 +54,4 @@ tzdata==2025.2
 urllib3==2.4.0
 xxhash==3.5.0
 yarl==1.20.0
+pydantic==2.5.2

--- a/src/configs/config.py
+++ b/src/configs/config.py
@@ -1,60 +1,14 @@
-"""
-config.py
-
-Defines application configuration schemas using Pydantic,
-and provides a helper to load and validate settings from a YAML file.
-"""
-
-from pydantic import BaseModel, Field
-from typing import List, Literal
 import yaml
+from pydantic import BaseModel
 
-# --- Model configuration schema ---
-class ModelConfig(BaseModel):
+class Config(BaseModel):
     """
-    Configuration for the transformer model hyperparameters.
+    Minimal configuration schema: only validates vocab_size.
     """
-    type: Literal["Joeyllm"]  # model type identifier
-    vocab_size: int = Field(..., gt=0, description="Size of the vocabulary")  # vocabulary size
-    max_seq_len: int = Field(..., gt=0, description="Max sequence length")  # max tokens per input
-    embed_dim: int = Field(..., gt=0, description="Embedding dimensionality")  # embedding vector size
-    num_heads: int = Field(..., gt=1, description="Attention heads")  # number of attention heads
-    num_layers: int = Field(..., gt=0, description="Transformer layers")  # number of transformer blocks
-    dropout: float = Field(..., ge=0, le=1, description="Dropout rate")  # dropout probability
-
-# --- Data pipeline configuration schema ---
-class DataConfig(BaseModel):
-    """
-    Configuration for data loading and preprocessing.
-    """
-    dataset_out: str  # path or identifier for output dataset
-    dataset_in: str  # path or identifier for input dataset
-    batch_size: int = Field(..., gt=0)  # batch size for data loader
-    columns: List[str]  # list of column names to include
-    format: Literal["torch", "tf", "np"]  # data format
-    shuffle: bool  # whether to shuffle the dataset
-    use_validation: bool  # whether to split out a validation set
-    use_test: bool  # whether to split out a test set
-
-# --- Training loop configuration schema ---
-class TrainConfig(BaseModel):
-    """
-    Configuration for the training loop parameters.
-    """
-    batch_size: int = Field(..., gt=0)  # batch size used during training
-    device: Literal["cpu", "gpu", "auto"] = "auto"  # device for training ('cpu', 'gpu', or 'auto')
-
-# --- Top-level application configuration ---
-class AppConfig(BaseModel):
-    """
-    Aggregates all configuration sections into one object.
-    """
-    model: ModelConfig  # model hyperparameters
-    data: DataConfig  # data processing settings
-    train: TrainConfig  # training settings
+    vocab_size: int  # vocabulary size
 
     @classmethod
-    def from_yaml(cls, path: str) -> "AppConfig":
+    def from_yaml(cls, path: str) -> "Config":
         """
         Load configuration from a YAML file and validate against the schema.
 
@@ -62,11 +16,8 @@ class AppConfig(BaseModel):
             path (str): Path to the YAML configuration file.
 
         Returns:
-            AppConfig: An instance populated with validated config values.
-
-        Raises:
-            pydantic.ValidationError: If the YAML does not conform to the schema.
+            Config: An instance populated with validated config values.
         """
-        with open(path, "r") as f:
+        with open(path, 'r') as f:
             raw = yaml.safe_load(f)
         return cls.parse_obj(raw)


### PR DESCRIPTION
Removed all previous schemas
The ModelConfig, DataConfig, TrainConfig and AppConfig classes (and their associated fields) have been deleted to strip the file back to its bare essentials.
Introduced a single Config model
– Uses Pydantic’s BaseModel
– Validates only one field:
vocab_size: int
This enforces that any loaded configuration must include an integer vocab_size.
Added a from_yaml loader method
– Reads raw YAML from a given file path
– Uses yaml.safe_load to parse it
– Calls Config.parse_obj(...) to perform Pydantic validation
– Returns a fully validated Config instance (or raises ValidationError on failure)