### PR TITLE
Move more runtime parameters into config

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -29,6 +29,8 @@ dataconfig:
   shuffle_min_buffer: 10000
   shuffle_buffer_multiplier: 5
   pin_memory: true
+  use_fast_tokenizer: true
+  streaming: true
 
 # -------------------------------
 # Model Config
@@ -77,5 +79,6 @@ trainconfig:
   accumulation_steps: 4
   save_model_path: model/a100model2.pt
   log_freq: 1000
+  non_blocking: true
 
 

--- a/configs/valid.py
+++ b/configs/valid.py
@@ -1,6 +1,5 @@
 from pydantic import BaseModel, Field
-from typing import List, Tuple
-from pydantic_settings import BaseSettings
+from typing import Tuple
 
 
 class WandBConfig(BaseModel):
@@ -19,6 +18,8 @@ class DataConfig(BaseModel):
     shuffle_min_buffer: int
     shuffle_buffer_multiplier: int
     pin_memory: bool
+    use_fast_tokenizer: bool
+    streaming: bool
         
 
 class ModelConfig(BaseModel):
@@ -41,6 +42,7 @@ class TrainConfig(BaseModel):
     accumulation_steps: int
     save_model_path: str
     log_freq: int
+    non_blocking: bool
 
 class SchedulerConfig(BaseModel):
     max_lr: float
@@ -60,3 +62,4 @@ class Config(BaseModel):
     optimizerconfig: OptimizerConfig
     schedulerconfig: SchedulerConfig
     trainconfig: TrainConfig
+

--- a/data/dataset.py
+++ b/data/dataset.py
@@ -71,11 +71,13 @@ def get_dataloader(
     shuffle_min_buffer,
     shuffle_buffer_multiplier,
     pin_memory,
+    use_fast_tokenizer,
+    streaming,
     world_size: int = 1,
     rank: int = 0,
     ):
 
-    tokenizer = AutoTokenizer.from_pretrained(tokenizer_path, use_fast=True)
+    tokenizer = AutoTokenizer.from_pretrained(tokenizer_path, use_fast=use_fast_tokenizer)
 
     buffer_size = max(shuffle_min_buffer, buffer_text_size * shuffle_buffer_multiplier)
 
@@ -83,7 +85,7 @@ def get_dataloader(
         dataset_name,
         data_dir=data_path,
         split="train",
-        streaming=True
+        streaming=streaming
     ).shuffle(buffer_size=buffer_size)
 
     if world_size > 1:

--- a/main.py
+++ b/main.py
@@ -57,6 +57,8 @@ def main(cfg: DictConfig):
         shuffle_min_buffer=vcfg.dataconfig.shuffle_min_buffer,
         shuffle_buffer_multiplier=vcfg.dataconfig.shuffle_buffer_multiplier,
         pin_memory=vcfg.dataconfig.pin_memory,
+        use_fast_tokenizer=vcfg.dataconfig.use_fast_tokenizer,
+        streaming=vcfg.dataconfig.streaming,
         world_size=world_size,
         rank=rank
     )
@@ -98,6 +100,7 @@ def main(cfg: DictConfig):
         accumulation_steps=vcfg.trainconfig.accumulation_steps,
         save_model_path=vcfg.trainconfig.save_model_path,
         log_freq=vcfg.trainconfig.log_freq,
+        non_blocking=vcfg.trainconfig.non_blocking,
     )
 
     trainer.train(epochs=vcfg.trainconfig.epochs)

--- a/train/trainer.py
+++ b/train/trainer.py
@@ -20,6 +20,7 @@ class Trainer:
         accumulation_steps: int,
         save_model_path: str,
         log_freq: int,
+        non_blocking: bool,
         device: torch.device = None,
     ):
         self.rank = rank
@@ -38,6 +39,7 @@ class Trainer:
         self.accumulation_steps = accumulation_steps
         self.save_model_path = save_model_path
         self.log_freq = log_freq
+        self.non_blocking = non_blocking
 
         # Mixed precision
         self.scaler = GradScaler()
@@ -74,8 +76,8 @@ class Trainer:
         self.model.train()
 
         for step, batch in enumerate(self.dataloader):
-            inputs = batch["inputs"].to(self.device, non_blocking=True)
-            labels = batch["labels"].to(self.device, non_blocking=True)
+            inputs = batch["inputs"].to(self.device, non_blocking=self.non_blocking)
+            labels = batch["labels"].to(self.device, non_blocking=self.non_blocking)
             
             if step % self.accumulation_steps == 0:
                 self.optimizer.zero_grad(set_to_none=True)


### PR DESCRIPTION
## Summary
- add tokenizer speed and streaming flags
- make copy-to-device async configurable
- support new options in dataloader and trainer

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_b_688976feec0c8320b26dc9340a53bd53